### PR TITLE
Corrected fixed suggested date on task completion

### DIFF
--- a/lambda/tasks/views.py
+++ b/lambda/tasks/views.py
@@ -249,7 +249,7 @@ class TaskCompleteView(
     model = Task
     form_class = forms.CompleteTaskForm
     initial = {
-        "date_completed": date.today(),
+        "date_completed": date.today,
     }
     success_message = "Task #%(id)s completed"
 


### PR DESCRIPTION
If we leave the bracket the system would evaluate the date at website creation only and then the suggested date will remain the same.
Without the bracket, it will evaluate the date properly every time the views get called.
Made the change yesterday and today the date is properly changed so I think it works.