### PR TITLE
Added unassigned task display for team members

### DIFF
--- a/lambda/tasks/views.py
+++ b/lambda/tasks/views.py
@@ -55,7 +55,7 @@ class UnassignedTaskListView(mixins.LoginRequiredMixin, generic.ListView):
     def get_queryset(self):
         q = Task.objects.none()
 
-        for project in Project.objects.filter(team__leader=self.request.user):
+        for project in (Project.objects.filter(team__leader=self.request.user) | Project.objects.filter(team__members__in=[self.request.user])):
             q = q | project.task_set.filter(assigned_to=None)
 
         return q.distinct().order_by("date_due", "-priority_level")

--- a/lambda/tasks/views.py
+++ b/lambda/tasks/views.py
@@ -56,7 +56,9 @@ class UnassignedTaskListView(mixins.LoginRequiredMixin, generic.ListView):
         q = Task.objects.none()
 
         for project in (Project.objects.filter(team__leader=self.request.user) | Project.objects.filter(team__members__in=[self.request.user])):
-            q = q | project.task_set.filter(assigned_to=None)
+            q = q | project.task_set.filter(assigned_to=None).filter(
+                completed=False
+            )
 
         return q.distinct().order_by("date_due", "-priority_level")
 

--- a/lambda/users/views.py
+++ b/lambda/users/views.py
@@ -127,7 +127,7 @@ class DashboardView(mixins.LoginRequiredMixin, generic.TemplateView):
 
         context["unassigned_task_list"] = (
             Task.objects.filter(completed=False)
-            .filter(team__leader=self.request.user)
+            .filter(team__members__in=[self.request.user])
             .filter(assigned_to=None)
             .order_by("date_due", "-priority_level")[:7]
         )


### PR DESCRIPTION
Solution to implement the unassigned display for user part of a team( not just team leaders).
Same for dashboard display.
Added the filter to remove completed task from the unassigned task pane (same as was implemented in dashboard)

On the dashboard, the filter I used is to show the task if user is a member of the team. 
On the unassigned task pane, I used the filter to show either the team leader or the project member. 

Not sure this is the same: Is a team leader always a member of a team?
